### PR TITLE
chore: specify no data collection in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,10 @@
 	],
 	"browser_specific_settings": {
 		"gecko": {
-			"id": "homepageomni@homepageomni.homepageomni"
+			"id": "homepageomni@homepageomni.homepageomni",
+			"data_collection_permissions": {
+				"required": ["none"]
+			}
 		}
 	}
 }


### PR DESCRIPTION
Meet Firefox's new requirement of explicitly specifying what data is collected. As this extension collects no data, it is set to none.