### PR TITLE
Add clock 12/24 mode and seconds toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Commands are prefixed with `:`.
 - `:delete {link name}` - Delete the link with the given name
 - `:show` - Show all links by default (when the omnibar is empty)
 - `:hide` - Hide all links by default
+- `:clockmode {12|24}` - Set clocks to 12-hour or 24-hour format
+- `:showseconds {on|off}` - Enable or disable seconds on clocks (omit argument to toggle)
 - `:export` - Export/save the configuration to a .json file
 - `:import` - Import/load the configuration from a .json file
 - `:resetconfig` - Reset the entire configuration (useful if corrupted)
@@ -121,6 +123,8 @@ Event object format example (creates an event Lunch Time at 12:25pm repeating ea
 - `clock2_utc_offset` - the UTC offset of the second clock (ex. for Tokyo, which is UTC+9, use `+9`)
 - `clock3_name` - the name of the third clock (right) (default `"hidden"`)
 - `clock3_utc_offset` - the UTC offset of the third clock
+- `clock_use_24h` - bool (default `true`; if `false`, clocks use 12-hour time with AM/PM)
+- `clock_show_seconds` - bool (default `false`; if `true`, clocks include seconds)
 
 If you set the name of a clock to be `"hidden"`, it will not appear; to hide all clocks, set them all to `"hidden"`.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Commands are prefixed with `:`.
 - `:show` - Show all links by default (when the omnibar is empty)
 - `:hide` - Hide all links by default
 - `:clockmode {12|24}` - Set clocks to 12-hour or 24-hour format
-- `:showseconds {on|off}` - Enable or disable seconds on clocks (omit argument to toggle)
+- `:showseconds {true|false}` - Enable or disable seconds on clocks (omit argument to toggle)
 - `:export` - Export/save the configuration to a .json file
 - `:import` - Import/load the configuration from a .json file
 - `:resetconfig` - Reset the entire configuration (useful if corrupted)

--- a/examples/default_homepage_omni_config.json
+++ b/examples/default_homepage_omni_config.json
@@ -21,6 +21,8 @@
 	"events": [],
 	"event_display_duration_mins": 60,
 	"clock1_name": "",
+	"clock_use_24h": true,
+	"clock_show_seconds": false,
 	"clock2_name": "hidden",
 	"clock2_utc_offset": 0,
 	"clock3_name": "hidden",

--- a/examples/feature_showcase_config.json
+++ b/examples/feature_showcase_config.json
@@ -61,6 +61,8 @@
 	],
 	"event_display_duration_mins": 120,
 	"clock1_name": "Local",
+	"clock_use_24h": true,
+	"clock_show_seconds": false,
 	"clock2_name": "🌍GMT",
 	"clock2_utc_offset": 0,
 	"clock3_name": "🗼Tokyo",

--- a/script.js
+++ b/script.js
@@ -333,7 +333,7 @@ function updateFiltered(new_value) {
 		helptext.innerText = "Set clock format (ex. :clockmode 12 or :clockmode 24)";
 	} else if (new_value.startsWith(":showseconds")) {
 		helptext.className = "normal";
-		helptext.innerText = "Toggle or set seconds (ex. :showseconds, :showseconds on, :showseconds off)";
+		helptext.innerText = "Toggle or set seconds (ex. :showseconds, :showseconds true, :showseconds false)";
 	} else if (new_value.startsWith(":") && helptext.innerText == "") {
 		helptext.className = "normal";
 		helptext.innerText = "Enter a command (ex. :set, :delete)";

--- a/script.js
+++ b/script.js
@@ -630,17 +630,39 @@ function updateClock() {
 	}
 }
 
-// Update each second (only if the page is visible)
-setInterval(() => {
+let clockTickTimeoutId = null;
+function scheduleNextClockTick() {
+	const now = Date.now();
+	const delayMs = 1000 - (now % 1000) || 1000;
+	clockTickTimeoutId = setTimeout(() => {
+		if (!document.hidden) {
+			updateClock();
+		}
+		scheduleNextClockTick();
+	}, delayMs);
+}
+
+function resyncClockTicker() {
+	if (clockTickTimeoutId !== null) {
+		clearTimeout(clockTickTimeoutId);
+		clockTickTimeoutId = null;
+	}
 	if (!document.hidden) {
 		updateClock();
 	}
-}, 1000);
+	scheduleNextClockTick();
+}
+
+document.addEventListener("visibilitychange", () => {
+	if (!document.hidden) {
+		resyncClockTicker();
+	}
+});
 
 // First time loading the page
 sortLinks();
 updateFiltered("");
 render();
-updateClock();
+resyncClockTicker();
 // Load config from storage, if possible
 loadConfig();

--- a/script.js
+++ b/script.js
@@ -162,9 +162,9 @@ function processInput(new_value) {
 			saveConfig();
 		} else if (new_value.startsWith(":clockmode")) {
 			const mode = new_value.substring(10).trim().toLowerCase();
-			if (mode == "24" || mode == "24h") {
+			if (mode === "24" || mode === "24h") {
 				config.clock_use_24h = true;
-			} else if (mode == "12" || mode == "12h") {
+			} else if (mode === "12" || mode === "12h") {
 				config.clock_use_24h = false;
 			} else {
 				error_text = "Usage: :clockmode {12|24}";
@@ -175,14 +175,14 @@ function processInput(new_value) {
 			return true;
 		} else if (new_value.startsWith(":showseconds")) {
 			const value = new_value.substring(12).trim().toLowerCase();
-			if (value == "") {
+			if (value === "") {
 				config.clock_show_seconds = !config.clock_show_seconds;
-			} else if (value == "on" || value == "true" || value == "yes" || value == "1") {
+			} else if (value === "true") {
 				config.clock_show_seconds = true;
-			} else if (value == "off" || value == "false" || value == "no" || value == "0") {
+			} else if (value === "false") {
 				config.clock_show_seconds = false;
 			} else {
-				error_text = "Usage: :showseconds {on|off}";
+				error_text = "Usage: :showseconds {true|false}";
 				return false;
 			}
 			saveConfig();

--- a/script.js
+++ b/script.js
@@ -633,7 +633,7 @@ function updateClock() {
 let clockTickTimeoutId = null;
 function scheduleNextClockTick() {
 	const now = Date.now();
-	const delayMs = 1000 - (now % 1000) || 1000;
+	const delayMs = 1000 - (now % 1000);
 	clockTickTimeoutId = setTimeout(() => {
 		if (!document.hidden) {
 			updateClock();

--- a/script.js
+++ b/script.js
@@ -33,6 +33,8 @@ const CONFIG_DEFAULT = {
 	"event_display_duration_mins": 60,
 	// Clocks (by default, only show clock 1)
 	"clock1_name": "",
+	"clock_use_24h": true,
+	"clock_show_seconds": false,
 	"clock2_name": "hidden",
 	"clock2_utc_offset": 0,
 	"clock3_name": "hidden",
@@ -158,6 +160,34 @@ function processInput(new_value) {
 		} else if (new_value == ":hide") {
 			config.display_when_empty = false;
 			saveConfig();
+		} else if (new_value.startsWith(":clockmode")) {
+			const mode = new_value.substring(10).trim().toLowerCase();
+			if (mode == "24" || mode == "24h") {
+				config.clock_use_24h = true;
+			} else if (mode == "12" || mode == "12h") {
+				config.clock_use_24h = false;
+			} else {
+				error_text = "Usage: :clockmode {12|24}";
+				return false;
+			}
+			saveConfig();
+			updateClock();
+			return true;
+		} else if (new_value.startsWith(":showseconds")) {
+			const value = new_value.substring(12).trim().toLowerCase();
+			if (value == "") {
+				config.clock_show_seconds = !config.clock_show_seconds;
+			} else if (value == "on" || value == "true" || value == "yes" || value == "1") {
+				config.clock_show_seconds = true;
+			} else if (value == "off" || value == "false" || value == "no" || value == "0") {
+				config.clock_show_seconds = false;
+			} else {
+				error_text = "Usage: :showseconds {on|off}";
+				return false;
+			}
+			saveConfig();
+			updateClock();
+			return true;
 		} else if (new_value.startsWith(":delete")) {
 			// Delete
 			return deleteLink(new_value.substring(7).trim());
@@ -298,6 +328,12 @@ function updateFiltered(new_value) {
 	if (error_text.length > 0) {
 		helptext.className = "error";
 		helptext.innerText = error_text;
+	} else if (new_value.startsWith(":clockmode")) {
+		helptext.className = "normal";
+		helptext.innerText = "Set clock format (ex. :clockmode 12 or :clockmode 24)";
+	} else if (new_value.startsWith(":showseconds")) {
+		helptext.className = "normal";
+		helptext.innerText = "Toggle or set seconds (ex. :showseconds, :showseconds on, :showseconds off)";
 	} else if (new_value.startsWith(":") && helptext.innerText == "") {
 		helptext.className = "normal";
 		helptext.innerText = "Enter a command (ex. :set, :delete)";
@@ -498,14 +534,33 @@ function padTime(time) {
 
 // Render a specific clock given its ID, a date, a region name, and whether to use UTC (for global clocks)
 function renderClock(clockid, d, region, useUTC) {
-	const hours = useUTC ? d.getUTCHours() : d.getHours();
+	const hours24 = useUTC ? d.getUTCHours() : d.getHours();
 	const minutes = useUTC ? d.getUTCMinutes() : d.getMinutes();
+	const seconds = useUTC ? d.getUTCSeconds() : d.getSeconds();
 	const fullYear = useUTC ? d.getUTCFullYear() : d.getFullYear();
 	const month = useUTC ? d.getUTCMonth() : d.getMonth();
 	const date = useUTC ? d.getUTCDate() : d.getDate();
 	const day = useUTC ? d.getUTCDay() : d.getDay();
+	const use24Hour = config.clock_use_24h !== false;
+	const showSeconds = config.clock_show_seconds === true;
 
-	const timeRender = `${padTime(hours)}:${padTime(minutes)}`;
+	let timeRender = "";
+	if (use24Hour) {
+		timeRender = `${padTime(hours24)}:${padTime(minutes)}`;
+		if (showSeconds) {
+			timeRender += `:${padTime(seconds)}`;
+		}
+	} else {
+		let hours12 = hours24 % 12;
+		if (hours12 == 0) hours12 = 12;
+		const ampm = hours24 >= 12 ? "PM" : "AM";
+		timeRender = `${hours12}:${padTime(minutes)}`;
+		if (showSeconds) {
+			timeRender += `:${padTime(seconds)}`;
+		}
+		timeRender += ` ${ampm}`;
+	}
+
 	const dateRender = `${fullYear}/${padTime(month + 1)}/${padTime(date)} - ${weekdays[day]}`;
 
 	document.getElementById("clockitem" + clockid).style.display = "inline";


### PR DESCRIPTION
Introduce :clockmode and :showseconds commands, plus config keys clock_use_24h and clock_show_seconds.

<img width="402" height="178" alt="image" src="https://github.com/user-attachments/assets/5f47fe68-a611-417f-93e0-a0b98e21eae8" />

Default behavior still uses 24-hour time with no seconds when not configured differently.
The options for showing seconds and 12/24 time are shared between clocks because I presume most users would want these to match.